### PR TITLE
Fix image height in Safari 16.4

### DIFF
--- a/src/components/banner-card/banner-card.less
+++ b/src/components/banner-card/banner-card.less
@@ -213,7 +213,6 @@
   max-width: 100%;
 
   &>img {
-    max-height: 100%;
     max-width: 100%;
   }
 


### PR DESCRIPTION
Remove max-heigh in banner images for Safari to show animations