### PR TITLE
Force html reload of image after load

### DIFF
--- a/src/components/banner-card/BannerPicture.tsx
+++ b/src/components/banner-card/BannerPicture.tsx
@@ -113,6 +113,7 @@ const BannerPicture: FC<BannerPictureProps> = ({
         </Button>
       </Modal>
       <div
+        key={`imageLoaded-${loaded}`}
         ref={ref}
         className={`banner-card-picture banner-lines-${lines}`}
         onClick={() => setModalOpened(showFullImage)}


### PR DESCRIPTION
Forces react component to reload HTML so Safari knows the correct heigh of images and it shows on iPhone