### PR TITLE
Include link to new open source repo #336

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -244,7 +244,7 @@
     "title": "Häufig gefragt",
     "question1": {
       "title": "Was ist bannergress.com?",
-      "answer": "<p>Nach dem Verlust unserer beliebten Ingress-Fansite haben sich einige Agents zusammengetan, um dieses Projekt auf die Beine zu stellen.</p><ul><li>alle einbinden</li><li>Open Source werden (bald)</li><li>dauerhafte Bibliothek für Banner sein</li><li>nie aufhören, weiterzuentwickeln</li></ul>"
+      "answer": "<p>Nach dem Verlust unserer beliebten Ingress-Fansite haben sich einige Agents zusammengetan, um dieses Projekt auf die Beine zu stellen. Das Ziel dieses Projektes ist es: </p><ul><li>alle einzubinden</li><li><github>Open Source</github> zu sein</li><li>die dauerhafte Bibliothek für Banner sein</li><li>nie aufzuhören, weiterzuentwickeln</li></ul>"
     },
     "question2": {
       "title": "Wie bekomme ich Ingress-Missionen nach bannergress.com? (Teil 1: Installation)",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -245,7 +245,7 @@
     "title": "Frequently Asked",
     "question1": {
       "title": "What is bannergress.com?",
-      "answer": "<p>After the horrific loss of our favorite Ingress fan page, some agents came together to start this project.</p><ul><li>get everyone involved</li><li>be open source (soon™)</li><li>be the long-term solution for finding banners</li><li>never stop developing</li></ul>"
+      "answer": "<p>After the horrific loss of our favorite Ingress fan page, some agents came together to start this project. The aim of the project is to:</p><ul><li>get everyone involved</li><li>be <github>open source</github></li><li>be the long-term solution for finding banners</li><li>never stop developing</li></ul>"
     },
     "question2": {
       "title": "How do I get Ingress missions to bannergress.com? (Part 1: setup)",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -220,7 +220,7 @@
     "title": "Preguntas frecuentes",
     "question1": {
       "title": "What is bannergress.com?",
-      "answer": "<p>After the horrific loss of our favorite Ingress fan page, some agents came together to start this project.</p><ul><li>get everyone involved</li><li>be open source (soon™)</li><li>be the long-term solution for finding banners</li><li>never stop developing</li></ul>"
+      "answer": "<p>After the horrific loss of our favorite Ingress fan page, some agents came together to start this project. The aim of the project is to:</p><ul><li>get everyone involved</li><li>be <github>open source</github></li><li>be the long-term solution for finding banners</li><li>never stop developing</li></ul>"
     },
     "question2": {
       "title": "How do I get Ingress missions to bannergress.com? (Part 1: setup)",

--- a/src/pages/help/AllQuestions.tsx
+++ b/src/pages/help/AllQuestions.tsx
@@ -20,6 +20,7 @@ export const AllQuestions: React.FC = () => {
         <Trans
           i18nKey="faqs.question1.answer"
           components={{
+            github: getLink('https://github.com/bannergress'),
             p: <p />,
             ul: <ul />,
             li: <li />,


### PR DESCRIPTION
Ticket #336 has a list of three things. I have addressed two of these

- remove the "soon" from being open source
- link to github

The third point, including the creator plugin, was already done in #334.

I've also changed the wording of the first question slightly to sound more idiomatic in both English and German (I am a native German speaker living in the UK).

![image](https://github.com/bannergress/website/assets/1125067/1b20a169-ea5a-472d-a507-c4e776226df4)
![image](https://github.com/bannergress/website/assets/1125067/f4efa8ca-9c20-45c3-b99e-a2f577cb9223)


Closes #336 